### PR TITLE
Fix help form incorrectly displaying return button

### DIFF
--- a/students-vs-teachers/FrmGame.cs
+++ b/students-vs-teachers/FrmGame.cs
@@ -137,7 +137,7 @@ namespace Students_vs_teachers
             tmrGameTick.Enabled = false;
             Visible = false;
 
-            var frmHelp = new FrmHelp();
+            var frmHelp = new FrmHelp(new FrmHelpConstructor { ReturnButtonText = "Game" });
             frmHelp.ShowDialog();
 
             // resume game

--- a/students-vs-teachers/FrmHelp.Designer.cs
+++ b/students-vs-teachers/FrmHelp.Designer.cs
@@ -66,6 +66,7 @@
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
             this.Name = "FrmHelp";
             this.WindowState = System.Windows.Forms.FormWindowState.Maximized;
+            this.Load += new System.EventHandler(this.FrmHelp_Load);
             this.ResumeLayout(false);
 
         }

--- a/students-vs-teachers/FrmHelp.cs
+++ b/students-vs-teachers/FrmHelp.cs
@@ -20,13 +20,15 @@ namespace Students_vs_teachers
             new HelpPageInfo { Image = Properties.Resources._02_helpImage },
         };
 
+        private FrmHelpConstructor data;
         private int pageNumber = 0;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FrmHelp"/> class.
         /// Creates the help menu.
         /// </summary>
-        public FrmHelp()
+        /// <param name="data">The data associated with the construction of this help form.</param>
+        public FrmHelp(FrmHelpConstructor data)
         {
             InitializeComponent();
 
@@ -34,7 +36,7 @@ namespace Students_vs_teachers
             FontLoader.LoadFont(btnPrevious, 12.0F);
             FontLoader.LoadFont(btnHome, 12.0F);
 
-            RefreshHelpImage();
+            this.data = data;
         }
 
         private void RefreshHelpImage()
@@ -61,6 +63,12 @@ namespace Students_vs_teachers
         {
             Dispose();
             Close();
+        }
+
+        private void FrmHelp_Load(object sender, System.EventArgs e)
+        {
+            btnHome.Text += $" {data.ReturnButtonText}";
+            RefreshHelpImage();
         }
     }
 }

--- a/students-vs-teachers/FrmHelp.resx
+++ b/students-vs-teachers/FrmHelp.resx
@@ -193,7 +193,7 @@
     <value>2</value>
   </data>
   <data name="btnHome.Text" xml:space="preserve">
-    <value>RETURN TO MENU</value>
+    <value>RETURN TO</value>
   </data>
   <data name="&gt;&gt;btnHome.Name" xml:space="preserve">
     <value>btnHome</value>

--- a/students-vs-teachers/FrmHelpConstructor.cs
+++ b/students-vs-teachers/FrmHelpConstructor.cs
@@ -1,0 +1,21 @@
+﻿// <summary>
+// Contains the FrmHelpConstructor interface.
+// </summary>
+// <copyright file="FrmHelpConstructor.cs" company="HBHS">
+// Copyright (c) HBHS. All rights reserved.
+// </copyright>
+
+namespace Students_vs_teachers
+{
+    /// <summary>
+    /// An interface used to construct a <b>frmHelp</b>.
+    /// </summary>
+    public struct FrmHelpConstructor
+    {
+        /// <summary>
+        /// The text to display when clicking on the return button.
+        /// For example, "Menu" would display "Return to Menu".
+        /// </summary>
+        public string ReturnButtonText;
+    }
+}

--- a/students-vs-teachers/frmMenu.cs
+++ b/students-vs-teachers/frmMenu.cs
@@ -52,7 +52,7 @@ namespace Students_vs_teachers
         {
             Visible = false;
 
-            var frmHelp = new FrmHelp();
+            var frmHelp = new FrmHelp(new FrmHelpConstructor { ReturnButtonText = "Menu" });
             frmHelp.ShowDialog();
 
             Visible = true;

--- a/students-vs-teachers/students_vs_teachers.csproj
+++ b/students-vs-teachers/students_vs_teachers.csproj
@@ -79,6 +79,7 @@
     <Compile Include="FrmHelp.Designer.cs">
       <DependentUpon>FrmHelp.cs</DependentUpon>
     </Compile>
+    <Compile Include="FrmHelpConstructor.cs" />
     <Compile Include="frmMenu.cs">
       <SubType>Form</SubType>
     </Compile>


### PR DESCRIPTION
When opening the help menu in game, the menu incorrectly says "Return to Home" instead of "Return to Game".

This PR fixes this issue.